### PR TITLE
Erlaubt `draft` als Option für dsadokumentation Klasse

### DIFF
--- a/extrapreamble.tex
+++ b/extrapreamble.tex
@@ -2,3 +2,17 @@
 \usepackage{amsthm}
 \usepackage{algorithm}
 \usepackage[noend]{algpseudocode}
+
+\usepackage{datetime}
+\usepackage[]{setspace}
+\usepackage{lineno}
+
+% Draft mode
+\KOMAoptions{draft=false}
+\makeatletter
+\@ifclasswith{dsadokumentation}{draft}{
+  \linenumbers
+  \setstretch{2}
+  \chead{\textit{Draft ver. \today \ \currenttime.}}
+}{}
+\makeatother

--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass{dsadokumentation}
+\documentclass[]{dsadokumentation}
 
 % Extra packages / definitions
 \input{extrapreamble.tex}


### PR DESCRIPTION
`\documentclass[draft]{dsadokumentation}`

=> 2x Zeilenabstand
=> Zeilennummerierung
=> Compile Time in Header